### PR TITLE
Added check for float values to ArrayUnpackTransformer::isJson

### DIFF
--- a/src/Flow/ETL/Transformer/ArrayUnpackTransformer.php
+++ b/src/Flow/ETL/Transformer/ArrayUnpackTransformer.php
@@ -115,7 +115,7 @@ final class ArrayUnpackTransformer implements Transformer
              */
             $value = \json_decode($string, true, self::JSON_DEPTH, JSON_THROW_ON_ERROR);
 
-            if (\is_int($value) || \is_float($value)) {
+            if (\is_numeric($value)) {
                 return false;
             }
 

--- a/src/Flow/ETL/Transformer/ArrayUnpackTransformer.php
+++ b/src/Flow/ETL/Transformer/ArrayUnpackTransformer.php
@@ -115,7 +115,7 @@ final class ArrayUnpackTransformer implements Transformer
              */
             $value = \json_decode($string, true, self::JSON_DEPTH, JSON_THROW_ON_ERROR);
 
-            if (\is_int($value)) {
+            if (\is_int($value) || \is_float($value)) {
                 return false;
             }
 

--- a/tests/Flow/ETL/Transformer/Tests/Unit/ArrayUnpackTransformerTest.php
+++ b/tests/Flow/ETL/Transformer/Tests/Unit/ArrayUnpackTransformerTest.php
@@ -67,6 +67,7 @@ final class ArrayUnpackTransformerTest extends TestCase
                             'json' => '["foo", "bar"]',
                             'object' => new \stdClass(),
                             'null' => null,
+                            'stringWithFloat' => '0.0',
                         ]),
                     ),
                 ),
@@ -84,7 +85,8 @@ final class ArrayUnpackTransformerTest extends TestCase
                     new Row\Entry\ArrayEntry('array', ['foo', 'bar']),
                     new Row\Entry\JsonEntry('json', ['foo', 'bar']),
                     new Row\Entry\ObjectEntry('object', new \stdClass()),
-                    new Row\Entry\NullEntry('null')
+                    new Row\Entry\NullEntry('null'),
+                    new Row\Entry\StringEntry('stringWithFloat', '0.0')
                 ),
             ),
             $rows


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Added `isFloat()` check to \Flow\ETL\Transformer\ArrayUnpackTransformer::isJson</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>
When string value had a `float`-y value, it was incorrectly detecting it as JSON string `TypeError: Argument 2 passed to Flow\ETL\Row\Entry\JsonEntry::__construct() must be of the type array, float given`
</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>`\Flow\ETL\Transformer\ArrayUnpackTransformer::isJson`</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->
