### PR TITLE
Added possibility to set prefix to array unpack

### DIFF
--- a/src/Flow/ETL/Transformer/ArrayUnpackTransformer.php
+++ b/src/Flow/ETL/Transformer/ArrayUnpackTransformer.php
@@ -17,12 +17,15 @@ final class ArrayUnpackTransformer implements Transformer
 {
     private string $arrayEntryName;
 
+    private ?string $entryPrefix;
+
     private EntryFactory $entryFactory;
 
-    public function __construct(string $arrayEntryName, EntryFactory $entryFactory = null)
+    public function __construct(string $arrayEntryName, ?string $entryPrefix = null, EntryFactory $entryFactory = null)
     {
         $this->arrayEntryName = $arrayEntryName;
         $this->entryFactory = $entryFactory ? $entryFactory : new NativeEntryFactory();
+        $this->entryPrefix = $entryPrefix;
     }
 
     /**
@@ -49,6 +52,10 @@ final class ArrayUnpackTransformer implements Transformer
              */
             foreach ($row->valueOf($this->arrayEntryName) as $key => $value) {
                 $entryName = (string) $key;
+
+                if ($this->entryPrefix) {
+                    $entryName = $this->entryPrefix . $entryName;
+                }
 
                 $entries = $entries->add($this->entryFactory->createEntry($entryName, $value));
             }

--- a/tests/Flow/ETL/Transformer/Tests/Unit/ArrayUnpackTransformerTest.php
+++ b/tests/Flow/ETL/Transformer/Tests/Unit/ArrayUnpackTransformerTest.php
@@ -156,4 +156,25 @@ final class ArrayUnpackTransformerTest extends TestCase
             $rows
         );
     }
+
+    public function test_array_unpack_with_prefix() : void
+    {
+        $rows = (new ArrayUnpackTransformer('inventory', 'inventory_'))
+            ->transform(
+                new Rows(
+                    Row::create(new Row\Entry\ArrayEntry('inventory', ['total' => 100, 'available' => 100, 'damaged' => 0]))
+                )
+            );
+
+        $this->assertSame(
+            [
+                [
+                    'inventory_total' => 100,
+                    'inventory_available' => 100,
+                    'inventory_damaged' => 0,
+                ],
+            ],
+            $rows->toArray()
+        );
+    }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>prefix to array unpack transformer</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->
