### PR TITLE
Only array values after json_decode are treated as a valid json value

### DIFF
--- a/src/Flow/ETL/Transformer/Factory/NativeEntryFactory.php
+++ b/src/Flow/ETL/Transformer/Factory/NativeEntryFactory.php
@@ -67,11 +67,7 @@ final class NativeEntryFactory implements EntryFactory
              */
             $value = \json_decode($string, true, self::JSON_DEPTH, JSON_THROW_ON_ERROR);
 
-            if (\is_numeric($value)) {
-                return false;
-            }
-
-            return true;
+            return \is_array($value);
         } catch (\Exception $e) {
             return false;
         }

--- a/tests/Flow/ETL/Transformer/Tests/Unit/ArrayUnpackTransformerTest.php
+++ b/tests/Flow/ETL/Transformer/Tests/Unit/ArrayUnpackTransformerTest.php
@@ -157,6 +157,26 @@ final class ArrayUnpackTransformerTest extends TestCase
         );
     }
 
+    public function test_array_unpack_with_null_as_string() : void
+    {
+        $arrayUnpackTransformer = new ArrayUnpackTransformer('array_entry');
+
+        $rows = (new RemoveEntriesTransformer('array_entry'))->transform(
+            $arrayUnpackTransformer->transform(
+                new Rows(
+                    Row::create(new Row\Entry\ArrayEntry('array_entry', ['status' => 'null']), ),
+                ),
+            )
+        );
+
+        $this->assertEquals(
+            new Rows(
+                Row::create(new Row\Entry\StringEntry('status', 'null')),
+            ),
+            $rows
+        );
+    }
+
     public function test_array_unpack_with_prefix() : void
     {
         $rows = (new ArrayUnpackTransformer('inventory', 'inventory_'))


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
<li>Treat all non arrays results of json_decode as invalid json in NativeEntryFactory</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

I have a problem with `ArrayUnpack` transformer. I used with CSV reports like that:
```php
ETL::extract(new LeagueCSVExtractor($reader, 100))
       ->transform(new ArrayUnpackTransformer('row'))
```
and it throws and exception:
```
TypeError: Argument 2 passed to Flow\ETL\Row\Entry\JsonEntry::__construct() must be of the type array, null given, called in NativeEntryFactory.php on line 21
```
It looks like a bug in `json_decode` function:
```php
var_dump(\json_decode('null', true, 512, \JSON_THROW_ON_ERROR));  
var_dump(\json_decode('1', true, 512, \JSON_THROW_ON_ERROR));
```
outputs:
```
NULL
int(1)
```
You can test it here: https://3v4l.org/cqHsL

This PR changes the logic for json validation to treat all non arrays results of `json_decode` as invalid json.