### PR TITLE
Add NullStringIntoNullEntryTransfromer

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,38 @@ $this->assertSame(
 );
 ```
 
+## Transformer - NullStringIntoNullEntry
+
+```php 
+
+use Flow\ETL\Row;
+use Flow\ETL\Rows;
+use Flow\ETL\Transformer\NullStringIntoNullEntryTransformer;
+
+$transformer = new NullStringIntoNullEntryTransformer('description', 'recommendation');
+
+$rows = $transformer->transform(new Rows(
+    Row::create(
+        new Row\Entry\IntegerEntry('id', 1),
+        new Row\Entry\BooleanEntry('active', false),
+        new Row\Entry\StringEntry('name', 'NULL'),
+        new Row\Entry\StringEntry('description', 'NULL'),
+        new Row\Entry\StringEntry('recommendation', 'null')
+    )
+));
+
+$this->assertSame(
+    [[
+        'id' => 1,
+        'active' => false,
+        'name' => 'NULL',
+        'description' => null,
+        'recommendation' => null,
+    ]],
+    $rows->toArray()
+);
+```
+
 ## Transformer - Clone 
 
 ```php 

--- a/src/Flow/ETL/Transformer/NullStringIntoNullEntryTransformer.php
+++ b/src/Flow/ETL/Transformer/NullStringIntoNullEntryTransformer.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Transformer;
+
+use Flow\ETL\Row;
+use Flow\ETL\Rows;
+use Flow\ETL\Transformer;
+
+/**
+ * @psalm-immutable
+ */
+final class NullStringIntoNullEntryTransformer implements Transformer
+{
+    /**
+     * @var string[]
+     */
+    private array $entryNames;
+
+    public function __construct(string ...$entryNames)
+    {
+        $this->entryNames = $entryNames;
+    }
+
+    public function transform(Rows $rows) : Rows
+    {
+        /**
+         * @psalm-var pure-callable(Row $row) : Row $transformer
+         */
+        $transformer = function (Row $row) : Row {
+            foreach ($this->entryNames as $entryName) {
+                $entry = $row->get($entryName);
+
+                if (!\is_string($entry->value())) {
+                    continue;
+                }
+
+                if (\mb_strtolower($entry->value()) === 'null') {
+                    $row = $row
+                        ->remove($entry->name())
+                        ->add(new Row\Entry\NullEntry($entry->name()));
+                }
+            }
+
+            return $row;
+        };
+
+        return $rows->map($transformer);
+    }
+}

--- a/tests/Flow/ETL/Transformer/Tests/Unit/NullStringIntoNullEntryTransformerTest.php
+++ b/tests/Flow/ETL/Transformer/Tests/Unit/NullStringIntoNullEntryTransformerTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Transformer\Tests\Unit;
+
+use Flow\ETL\Row;
+use Flow\ETL\Rows;
+use Flow\ETL\Transformer\NullStringIntoNullEntryTransformer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @psalm-immutable
+ */
+final class NullStringIntoNullEntryTransformerTest extends TestCase
+{
+    public function test_transforms_null_string_entries_into_null_entries() : void
+    {
+        $transformer = new NullStringIntoNullEntryTransformer('description', 'recommendation');
+
+        $rows = $transformer->transform(new Rows(
+            Row::create(
+                new Row\Entry\IntegerEntry('id', 1),
+                new Row\Entry\BooleanEntry('active', false),
+                new Row\Entry\StringEntry('name', 'NULL'),
+                new Row\Entry\StringEntry('description', 'NULL'),
+                new Row\Entry\StringEntry('recommendation', 'null')
+            )
+        ));
+
+        $this->assertSame(
+            [[
+                'id' => 1,
+                'active' => false,
+                'name' => 'NULL',
+                'description' => null,
+                'recommendation' => null,
+            ]],
+            $rows->toArray()
+        );
+    }
+}


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
<li>NullStringIntoNullEntryTransfromer implementation</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

In this PR https://github.com/flow-php/etl-transformer/pull/44 I fixed `NativeTransformer`. `ArrayUnpack` will create `StringEntry` with `NULL` values as strings. Here I added a transformer to transform those entires into `NullEntry`.
