### PR TITLE
Add sort entries transformer

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,37 @@ $this->assertSame(
 );
 ```
 
+## Transformer - SortEntries
+
+```php
+use Flow\ETL\Row;
+use Flow\ETL\Rows;
+use Flow\ETL\Transformer\SortEntriesTransformer;
+
+$transformer = new SortEntriesTransformer();
+
+$rows = $transformer->transform(new Rows(
+    Row::create(
+        new Row\Entry\IntegerEntry('id', 1),
+        new Row\Entry\BooleanEntry('active', true),
+        new Row\Entry\StringEntry('name', 'entry one'),
+    ),
+    Row::create(
+        new Row\Entry\StringEntry('name', 'entry two'),
+        new Row\Entry\IntegerEntry('id', 2),
+        new Row\Entry\BooleanEntry('active', true),
+    )
+));
+
+$this->assertSame(
+    [
+        ['active' => true, 'id' => 1, 'name' => 'entry one'],
+        ['active' => true, 'id' => 2, 'name' => 'entry two'],
+    ],
+    $rows->toArray()
+);
+```
+
 ## Development
 
 In order to install dependencies please, launch following commands:

--- a/src/Flow/ETL/Transformer/SortEntriesTransformer.php
+++ b/src/Flow/ETL/Transformer/SortEntriesTransformer.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Transformer;
+
+use Flow\ETL\Rows;
+use Flow\ETL\Transformer;
+
+/**
+ * @psalm-immutable
+ */
+final class SortEntriesTransformer implements Transformer
+{
+    public function transform(Rows $rows) : Rows
+    {
+        return $rows->sortEntries();
+    }
+}

--- a/tests/Flow/ETL/Transformer/Tests/Unit/SortEntriesTransformerTest.php
+++ b/tests/Flow/ETL/Transformer/Tests/Unit/SortEntriesTransformerTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Transformer\Tests\Unit;
+
+use Flow\ETL\Row;
+use Flow\ETL\Rows;
+use Flow\ETL\Transformer\SortEntriesTransformer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @psalm-immutable
+ */
+final class SortEntriesTransformerTest extends TestCase
+{
+    public function test_sorts_entries_by_name() : void
+    {
+        $transformer = new SortEntriesTransformer();
+
+        $rows = $transformer->transform(new Rows(
+            Row::create(
+                new Row\Entry\IntegerEntry('id', 1),
+                new Row\Entry\BooleanEntry('active', true),
+                new Row\Entry\StringEntry('name', 'entry one'),
+            ),
+            Row::create(
+                new Row\Entry\StringEntry('name', 'entry two'),
+                new Row\Entry\IntegerEntry('id', 2),
+                new Row\Entry\BooleanEntry('active', true),
+            )
+        ));
+
+        $this->assertSame(
+            [
+                ['active' => true, 'id' => 1, 'name' => 'entry one'],
+                ['active' => true, 'id' => 2, 'name' => 'entry two'],
+            ],
+            $rows->toArray()
+        );
+    }
+}


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
<li>Added SortEntries transformer</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

It's useful when transforming rows in a way that they are being replaced by new values. It may happen that order of entires in rows will change. It's a problem when using `dbal-bulk-loader`, because it requires the same order for all rows: https://github.com/flow-php/doctrine-dbal-bulk/blob/1.x/src/Flow/Doctrine/Bulk/BulkData.php#L43. I'm not sure if adding so simple transformer is a way to go. Not sure if it will be useful for anything else. Maybe it would be better to just sort all the entires before the insert, here: https://github.com/flow-php/etl-adapter-doctrine/blob/1.x/src/Flow/ETL/Adapter/Doctrine/DbalBulkLoader.php#L81
