### PR TITLE
Fixed naming for string concat transformer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [Unreleased] - 2021-06-24
 
 ### Added
-- [#54](https://github.com/flow-php/etl-transformer/pull/54) - **StringContactTransformer** - [@norberttech](https://github.com/norberttech)
+- [#54](https://github.com/flow-php/etl-transformer/pull/54) - **StringConcatTransformer** - [@norberttech](https://github.com/norberttech)
 - [#53](https://github.com/flow-php/etl-transformer/pull/53) - **ArrayAccessorTransformer** - [@norberttech](https://github.com/norberttech)
 - [#51](https://github.com/flow-php/etl-transformer/pull/51) - **ObjectMethodTransformer** - [@norberttech](https://github.com/norberttech)
 - [#48](https://github.com/flow-php/etl-transformer/pull/48) - **EntryExists filter for FilterRowsTransformer** - [@norberttech](https://github.com/norberttech)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [Unreleased] - 2021-06-24
 
 ### Added
-- [#54](https://github.com/flow-php/etl-transformer/pull/54) - **StringConcatTransformer** - [@norberttech](https://github.com/norberttech)
+- [#54](https://github.com/flow-php/etl-transformer/pull/54) - **StringContactTransformer** - [@norberttech](https://github.com/norberttech)
 - [#53](https://github.com/flow-php/etl-transformer/pull/53) - **ArrayAccessorTransformer** - [@norberttech](https://github.com/norberttech)
 - [#51](https://github.com/flow-php/etl-transformer/pull/51) - **ObjectMethodTransformer** - [@norberttech](https://github.com/norberttech)
 - [#48](https://github.com/flow-php/etl-transformer/pull/48) - **EntryExists filter for FilterRowsTransformer** - [@norberttech](https://github.com/norberttech)

--- a/README.md
+++ b/README.md
@@ -560,9 +560,9 @@ Entries that are not StringEntry type will be skipped even if entry exists
 
 use Flow\ETL\Row;
 use Flow\ETL\Rows;
-use Flow\ETL\Transformer\StringContactTransformer;
+use Flow\ETL\Transformer\StringConcatTransformer;
 
-$transformer = new StringContactTransformer([
+$transformer = new StringConcatTransformer([
     'id', 'first_name', 'last_name'
 ]);
 

--- a/src/Flow/ETL/Transformer/StringConcatTransformer.php
+++ b/src/Flow/ETL/Transformer/StringConcatTransformer.php
@@ -11,7 +11,7 @@ use Flow\ETL\Transformer;
 /**
  * @psalm-immutable
  */
-final class StringContactTransformer implements Transformer
+final class StringConcatTransformer implements Transformer
 {
     /**
      * @var array<string>

--- a/tests/Flow/ETL/Transformer/Tests/Unit/StringConcatTransformerTest.php
+++ b/tests/Flow/ETL/Transformer/Tests/Unit/StringConcatTransformerTest.php
@@ -6,14 +6,14 @@ namespace Flow\ETL\Transformer\Tests\Unit;
 
 use Flow\ETL\Row;
 use Flow\ETL\Rows;
-use Flow\ETL\Transformer\StringContactTransformer;
+use Flow\ETL\Transformer\StringConcatTransformer;
 use PHPUnit\Framework\TestCase;
 
-final class StringContactTransformerTest extends TestCase
+final class StringConcatTransformerTest extends TestCase
 {
     public function test_string_contact() : void
     {
-        $transformer = new StringContactTransformer([
+        $transformer = new StringConcatTransformer([
             'id', 'first_name', 'last_name',
         ]);
 
@@ -40,7 +40,7 @@ final class StringContactTransformerTest extends TestCase
 
     public function test_string_contact_with_non_string_value() : void
     {
-        $transformer = new StringContactTransformer([
+        $transformer = new StringConcatTransformer([
             'id', 'first_name', 'last_name',
         ]);
 


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>naming for string concat transformer</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->
