### PR TITLE
Improve ArrayAccessorTransformer by adding wildacrd support to path analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,35 @@ $this->assertSame(
 Access ArrayEntry value by path in dot notation and create new entry from result.
 When strictPath parameter is set to false it creates NullEntry even if path is invalid.
 
+Path allows using wildcards `*` in order to extract values from collections.
+
+```
+[
+    "users" => [
+        ["id" => 1],
+        ["id" => 2]
+    ]
+]
+```
+
+Path: `users.*.id` == `[1, 2]`
+
+When not all elements of the collection have same structure, use `?*` to avoid
+throwing invalid path exception and.
+
+```
+[
+    "users" => [
+        ["id" => 1],
+        ["empty" => true]
+    ]
+]
+```
+
+Path: `users.?*.id` == `[1]`
+
+Both special selectors, `*` and `?*` can also be escaped `\\*` and `\\?*`.
+
 ```php 
 
 use Flow\ETL\Exception\RuntimeException;

--- a/tests/Flow/ETL/Transformer/Tests/Unit/Accessor/ArrayAccessorTest.php
+++ b/tests/Flow/ETL/Transformer/Tests/Unit/Accessor/ArrayAccessorTest.php
@@ -113,9 +113,9 @@ final class ArrayAccessorTest extends TestCase
             ],
             ArrayAccessor::value(
                 ['transactions' => [
-                        ['id' => 1, 'packages' => [['label_id' => '12345'], ['label_id' => '22222']]],
-                        ['id' => 1, 'packages' => [['label_id' => '3333']]],
-                    ],
+                    ['id' => 1, 'packages' => [['label_id' => '12345'], ['label_id' => '22222']]],
+                    ['id' => 1, 'packages' => [['label_id' => '3333']]],
+                ],
                 ],
                 'transactions.*.packages.*.label_id'
             ),

--- a/tests/Flow/ETL/Transformer/Tests/Unit/Accessor/ArrayAccessorTest.php
+++ b/tests/Flow/ETL/Transformer/Tests/Unit/Accessor/ArrayAccessorTest.php
@@ -17,7 +17,7 @@ final class ArrayAccessorTest extends TestCase
         $this->assertFalse(ArrayAccessor::pathExists(['user' => ['id' => 1]], 'invalid_path'));
     }
 
-    public function test_accessing_next_array_value_by_numeric_path() : void
+    public function test_accessing_nested_array_value_by_numeric_path() : void
     {
         $this->assertSame(ArrayAccessor::value(['users' => [['user' => ['id' => 1]]]], 'users.0.user.id'), 1);
     }
@@ -36,5 +36,89 @@ final class ArrayAccessorTest extends TestCase
         $this->expectExceptionMessage('Path "invalid_path" does not exists in array "array()"');
 
         $this->assertSame(ArrayAccessor::value([], 'invalid_path'), 1);
+    }
+
+    public function test_accessing_array_scalar_value_by_path_with_asterix() : void
+    {
+        $this->assertSame(
+            ['Michael', 'Jack'],
+            ArrayAccessor::value(
+                ['users' => [['user' => ['id' => 1, 'name' => 'Michael']], ['user' => ['id' => 2, 'name' => 'Jack']]]],
+                'users.*.user.name'
+            ),
+        );
+    }
+
+    public function test_accessing_array_value_by_path_with_asterix() : void
+    {
+        $this->assertSame(
+            [['id' => 1, 'name' => 'Michael'], ['id' => 2, 'name' => 'Jack']],
+            ArrayAccessor::value(
+                ['users' => [['user' => ['id' => 1, 'name' => 'Michael']], ['user' => ['id' => 2, 'name' => 'Jack']]]],
+                'users.*.user'
+            ),
+        );
+    }
+
+    public function test_accessing_array_scalar_value_by_path_with_asterix_and_different_elements() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Path \"user.name\" does not exists in array \"array('user'=>array('id'=>2,),)\"");
+
+        ArrayAccessor::value(
+            ['users' => [['user' => ['id' => 1, 'name' => 'Michael']], ['user' => ['id' => 2]]]],
+            'users.*.user.name'
+        );
+    }
+
+    public function test_accessing_array_scalar_value_by_path_with_escaped_asterix_key() : void
+    {
+        $this->assertSame(
+            'Michael',
+            ArrayAccessor::value(
+                ['users' => ['*' => ['id' => 1, 'name' => 'Michael']]],
+                'users.\\*.name'
+            ),
+        );
+    }
+
+    public function test_accessing_array_scalar_value_by_path_with_nullable_asterix_and_different_elements() : void
+    {
+        $this->assertSame(
+            ['Michael'],
+            ArrayAccessor::value(
+                ['users' => [['user' => ['id' => 1, 'name' => 'Michael']], ['user' => ['id' => 2]]]],
+                'users.?*.user.name'
+            ),
+        );
+    }
+
+    public function test_accessing_array_scalar_value_by_path_with_escaped_nullable_asterix() : void
+    {
+        $this->assertSame(
+            'Michael',
+            ArrayAccessor::value(
+                ['users' => ['?*' => ['id' => 1, 'name' => 'Michael']]],
+                'users.\\?*.name'
+            )
+        );
+    }
+
+    public function test_accessing_array_scalar_value_by_path_multiple_asterix_paths() : void
+    {
+        $this->assertSame(
+            [
+                ['12345', '22222'],
+                ['3333'],
+            ],
+            ArrayAccessor::value(
+                ['transactions' => [
+                        ['id' => 1, 'packages' => [['label_id' => '12345'], ['label_id' => '22222']]],
+                        ['id' => 1, 'packages' => [['label_id' => '3333']]],
+                    ],
+                ],
+                'transactions.*.packages.*.label_id'
+            ),
+        );
     }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>ArrayAccessor - <code>*</code> special path character</li>
    <li>ArrayAccessor - <code>?*</code> special path character</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->
