### PR TITLE
Don't remove unpacked entry

### DIFF
--- a/src/Flow/ETL/Transformer/ArrayUnpackTransformer.php
+++ b/src/Flow/ETL/Transformer/ArrayUnpackTransformer.php
@@ -44,8 +44,6 @@ final class ArrayUnpackTransformer implements Transformer
                 throw new RuntimeException("\"{$this->arrayEntryName}\" is not ArrayEntry");
             }
 
-            $entries = $row->entries()->remove($this->arrayEntryName);
-
             /**
              * @var int|string $key
              * @var mixed $value
@@ -57,10 +55,10 @@ final class ArrayUnpackTransformer implements Transformer
                     $entryName = $this->entryPrefix . $entryName;
                 }
 
-                $entries = $entries->add($this->entryFactory->createEntry($entryName, $value));
+                $row = $row->add($this->entryFactory->createEntry($entryName, $value));
             }
 
-            return new Row($entries);
+            return $row;
         });
     }
 }

--- a/src/Flow/ETL/Transformer/Factory/ArrayRowsFactory.php
+++ b/src/Flow/ETL/Transformer/Factory/ArrayRowsFactory.php
@@ -8,6 +8,7 @@ use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Row;
 use Flow\ETL\Rows;
 use Flow\ETL\Transformer\ArrayUnpackTransformer;
+use Flow\ETL\Transformer\RemoveEntriesTransformer;
 use Flow\ETL\Transformer\RowsFactory;
 
 final class ArrayRowsFactory implements RowsFactory
@@ -21,11 +22,13 @@ final class ArrayRowsFactory implements RowsFactory
             }
         }
 
-        return (new ArrayUnpackTransformer('element'))->transform(new Rows(...\array_map(
-            function (array $row) : Row {
-                return Row::create(new Row\Entry\ArrayEntry('element', $row));
-            },
-            $data
-        )));
+        return (new RemoveEntriesTransformer('element'))->transform(
+            (new ArrayUnpackTransformer('element'))->transform(new Rows(...\array_map(
+                function (array $row) : Row {
+                    return Row::create(new Row\Entry\ArrayEntry('element', $row));
+                },
+                $data
+            )))
+        );
     }
 }

--- a/tests/Flow/ETL/Transformer/Tests/Unit/ArrayExpandTransformerTest.php
+++ b/tests/Flow/ETL/Transformer/Tests/Unit/ArrayExpandTransformerTest.php
@@ -9,6 +9,7 @@ use Flow\ETL\Row;
 use Flow\ETL\Rows;
 use Flow\ETL\Transformer\ArrayExpandTransformer;
 use Flow\ETL\Transformer\ArrayUnpackTransformer;
+use Flow\ETL\Transformer\RemoveEntriesTransformer;
 use PHPUnit\Framework\TestCase;
 
 final class ArrayExpandTransformerTest extends TestCase
@@ -93,7 +94,9 @@ final class ArrayExpandTransformerTest extends TestCase
                     'float' => 10.01,
                 ],
             ],
-            (new ArrayUnpackTransformer('element'))->transform($rows)->toArray()
+            (new RemoveEntriesTransformer('element'))->transform(
+                (new ArrayUnpackTransformer('element'))->transform($rows)
+            )->toArray()
         );
     }
 

--- a/tests/Flow/ETL/Transformer/Tests/Unit/ArrayUnpackTransformerTest.php
+++ b/tests/Flow/ETL/Transformer/Tests/Unit/ArrayUnpackTransformerTest.php
@@ -189,6 +189,7 @@ final class ArrayUnpackTransformerTest extends TestCase
         $this->assertSame(
             [
                 [
+                    'inventory' => ['total' => 100, 'available' => 100, 'damaged' => 0],
                     'inventory_total' => 100,
                     'inventory_available' => 100,
                     'inventory_damaged' => 0,


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
<li>Don't remove unpacked entry</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

I have a use case when I still need an unpacked entry in its original form. It should not be removed automatically. For example `ObjectTransformer` does not remove the original entry and I think this is the way to go here as well.
