### PR TITLE
Add option to skip some entries when unpacking an array

### DIFF
--- a/src/Flow/ETL/Transformer/ArrayUnpackTransformer.php
+++ b/src/Flow/ETL/Transformer/ArrayUnpackTransformer.php
@@ -20,19 +20,19 @@ final class ArrayUnpackTransformer implements Transformer
     /**
      * @var string[]
      */
-    private array $skipEntries;
+    private array $skipEntryNames;
 
     private ?string $entryPrefix;
 
     private EntryFactory $entryFactory;
 
     /**
-     * @param string[] $skipEntries
+     * @param string[] $skipEntryNames
      */
-    public function __construct(string $arrayEntryName, array $skipEntries = [], ?string $entryPrefix = null, EntryFactory $entryFactory = null)
+    public function __construct(string $arrayEntryName, array $skipEntryNames = [], ?string $entryPrefix = null, EntryFactory $entryFactory = null)
     {
         $this->arrayEntryName = $arrayEntryName;
-        $this->skipEntries = $skipEntries;
+        $this->skipEntryNames = $skipEntryNames;
         $this->entryFactory = $entryFactory ?? new NativeEntryFactory();
         $this->entryPrefix = $entryPrefix;
     }
@@ -60,7 +60,7 @@ final class ArrayUnpackTransformer implements Transformer
             foreach ($row->valueOf($this->arrayEntryName) as $key => $value) {
                 $entryName = (string) $key;
 
-                if (\in_array($entryName, $this->skipEntries, true)) {
+                if (\in_array($entryName, $this->skipEntryNames, true)) {
                     continue;
                 }
 

--- a/src/Flow/ETL/Transformer/ArrayUnpackTransformer.php
+++ b/src/Flow/ETL/Transformer/ArrayUnpackTransformer.php
@@ -17,14 +17,23 @@ final class ArrayUnpackTransformer implements Transformer
 {
     private string $arrayEntryName;
 
+    /**
+     * @var string[]
+     */
+    private array $skipEntries;
+
     private ?string $entryPrefix;
 
     private EntryFactory $entryFactory;
 
-    public function __construct(string $arrayEntryName, ?string $entryPrefix = null, EntryFactory $entryFactory = null)
+    /**
+     * @param string[] $skipEntries
+     */
+    public function __construct(string $arrayEntryName, array $skipEntries = [], ?string $entryPrefix = null, EntryFactory $entryFactory = null)
     {
         $this->arrayEntryName = $arrayEntryName;
-        $this->entryFactory = $entryFactory ? $entryFactory : new NativeEntryFactory();
+        $this->skipEntries = $skipEntries;
+        $this->entryFactory = $entryFactory ?? new NativeEntryFactory();
         $this->entryPrefix = $entryPrefix;
     }
 
@@ -50,6 +59,10 @@ final class ArrayUnpackTransformer implements Transformer
              */
             foreach ($row->valueOf($this->arrayEntryName) as $key => $value) {
                 $entryName = (string) $key;
+
+                if (\in_array($entryName, $this->skipEntries, true)) {
+                    continue;
+                }
 
                 if ($this->entryPrefix) {
                     $entryName = $this->entryPrefix . $entryName;

--- a/tests/Flow/ETL/Transformer/Tests/Unit/ArrayUnpackTransformerTest.php
+++ b/tests/Flow/ETL/Transformer/Tests/Unit/ArrayUnpackTransformerTest.php
@@ -179,7 +179,7 @@ final class ArrayUnpackTransformerTest extends TestCase
 
     public function test_array_unpack_with_prefix() : void
     {
-        $rows = (new ArrayUnpackTransformer('inventory', 'inventory_'))
+        $rows = (new ArrayUnpackTransformer('inventory', [], 'inventory_'))
             ->transform(
                 new Rows(
                     Row::create(new Row\Entry\ArrayEntry('inventory', ['total' => 100, 'available' => 100, 'damaged' => 0]))
@@ -193,6 +193,26 @@ final class ArrayUnpackTransformerTest extends TestCase
                     'inventory_total' => 100,
                     'inventory_available' => 100,
                     'inventory_damaged' => 0,
+                ],
+            ],
+            $rows->toArray()
+        );
+    }
+
+    public function test_array_unpack_with_skipped_entries() : void
+    {
+        $rows = (new ArrayUnpackTransformer('inventory', ['available', 'damaged']))
+            ->transform(
+                new Rows(
+                    Row::create(new Row\Entry\ArrayEntry('inventory', ['total' => 100, 'available' => 100, 'damaged' => 0]))
+                )
+            );
+
+        $this->assertSame(
+            [
+                [
+                    'inventory' => ['total' => 100, 'available' => 100, 'damaged' => 0],
+                    'total' => 100,
                 ],
             ],
             $rows->toArray()


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
<li>Add option to skip some entries when unpacking an array with ArrayUnpackTransformer</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

To unpack only part of an ArrayEntry, I added an option to pass entries that will be skipped.
