### PR TITLE
Removed strict from ArrayDotGet transformer and added new entry element name

### DIFF
--- a/src/Flow/ETL/Transformer/ArrayDotGetTransformer.php
+++ b/src/Flow/ETL/Transformer/ArrayDotGetTransformer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Transformer;
 
-use function Flow\ArrayDot\array_dot_exists;
 use function Flow\ArrayDot\array_dot_get;
 use Flow\ETL\Exception\RuntimeException;
 use Flow\ETL\Row;
@@ -21,19 +20,19 @@ final class ArrayDotGetTransformer implements Transformer
 
     private string $path;
 
-    private bool $strictPath;
+    private string $newEntryName;
 
     private EntryFactory $entryFactory;
 
     public function __construct(
         string $arrayEntryName,
         string $path,
-        bool $strictPath = true,
+        string $newEntryName = 'element',
         EntryFactory $entryFactory = null
     ) {
         $this->arrayEntryName = $arrayEntryName;
         $this->path = $path;
-        $this->strictPath = $strictPath;
+        $this->newEntryName = $newEntryName;
         $this->entryFactory = $entryFactory ? $entryFactory : new NativeEntryFactory();
     }
 
@@ -51,13 +50,9 @@ final class ArrayDotGetTransformer implements Transformer
                 throw new RuntimeException("{$this->arrayEntryName} is not ArrayEntry but {$entryClass}");
             }
 
-            if ($this->strictPath === false && !array_dot_exists($arrayEntry->value(), $this->path)) {
-                return $row->add(new Row\Entry\NullEntry($this->path));
-            }
-
             return $row->add(
                 $this->entryFactory->createEntry(
-                    $this->path,
+                    $this->newEntryName,
                     array_dot_get($arrayEntry->value(), $this->path)
                 )
             );

--- a/tests/Flow/ETL/Transformer/Tests/Unit/ArrayDotGetTransformerTest.php
+++ b/tests/Flow/ETL/Transformer/Tests/Unit/ArrayDotGetTransformerTest.php
@@ -47,19 +47,19 @@ final class ArrayDotGetTransformerTest extends TestCase
         );
 
         $this->assertEquals(
-            new Row\Entry\StringEntry('array.foo', 'bar'),
-            $rows->first()->get('array.foo')
+            new Row\Entry\StringEntry('element', 'bar'),
+            $rows->first()->get('element')
         );
     }
 
     public function test_array_accessor_transformer_with_invalid_but_strict_path() : void
     {
-        $arrayAccessorTransformer = new ArrayDotGetTransformer('array_entry', 'invalid_path', true);
+        $arrayAccessorTransformer = new ArrayDotGetTransformer('array_entry', 'invalid_path');
 
         $this->expectException(InvalidPathException::class);
         $this->expectExceptionMessage('Path "invalid_path" does not exists in array ');
 
-        $rows = $arrayAccessorTransformer->transform(
+        $arrayAccessorTransformer->transform(
             new Rows(
                 Row::create(
                     new Row\Entry\ArrayEntry('array_entry', [
@@ -76,7 +76,7 @@ final class ArrayDotGetTransformerTest extends TestCase
 
     public function test_array_accessor_transformer_with_invalid_and_without_strict_path() : void
     {
-        $arrayAccessorTransformer = new ArrayDotGetTransformer('array_entry', 'invalid_path', false);
+        $arrayAccessorTransformer = new ArrayDotGetTransformer('array_entry', '?invalid_path');
 
         $rows = $arrayAccessorTransformer->transform(
             new Rows(
@@ -93,8 +93,8 @@ final class ArrayDotGetTransformerTest extends TestCase
         );
 
         $this->assertEquals(
-            new Row\Entry\NullEntry('invalid_path'),
-            $rows->first()->get('invalid_path')
+            new Row\Entry\NullEntry('element'),
+            $rows->first()->get('element')
         );
     }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">

  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>ArrayDotGetTransformer new element name is no longer path but transformer argument</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <li>strict parameter from ArrayDotGetTransformer</li>
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->
