### PR TITLE
Fix a bug in CastEntries

### DIFF
--- a/src/Flow/ETL/Transformer/Cast/CastEntries.php
+++ b/src/Flow/ETL/Transformer/Cast/CastEntries.php
@@ -39,7 +39,7 @@ abstract class CastEntries implements CastRow
                 $entry = $row->entries()->get($entryName);
 
                 if ($this->nullable && $entry instanceof Row\Entry\NullEntry) {
-                    return $row;
+                    continue;
                 }
 
                 $row = new Row($row->entries()

--- a/tests/Flow/ETL/Transformer/Tests/Unit/CastTransformerTest.php
+++ b/tests/Flow/ETL/Transformer/Tests/Unit/CastTransformerTest.php
@@ -200,4 +200,25 @@ final class CastTransformerTest extends TestCase
         $this->assertInstanceOf(Row\Entry\ArrayEntry::class, $rows->first()->get('ids'));
         $this->assertSame([123456], $rows->first()->valueOf('ids'));
     }
+
+    public function test_casts_multiple_entries_with_null_entry_in_betwee() : void
+    {
+        $transformer = new CastTransformer(new CastToInteger(['id', 'limit', 'current'], $nullable = true));
+
+        $rows = $transformer->transform(new Rows(
+            Row::create(
+                new StringEntry('id', '1'),
+                new NullEntry('limit'),
+                new StringEntry('current', '10')
+            )
+        ));
+
+        $this->assertInstanceOf(IntegerEntry::class, $rows->first()->get('id'));
+        $this->assertSame(1, $rows->first()->valueOf('id'));
+
+        $this->assertInstanceOf(NullEntry::class, $rows->first()->get('limit'));
+
+        $this->assertInstanceOf(IntegerEntry::class, $rows->first()->get('current'));
+        $this->assertSame(10, $rows->first()->valueOf('current'));
+    }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
<li>Fix a bug in CastEntries when casting was interrupted on the first NullEntry if the nullable option was enabled</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>
