### PR TITLE
Removed abstract definition from CastEntries and CastArrayEntryEach class

### DIFF
--- a/src/Flow/ETL/Transformer/Cast/CastArrayEntryEach.php
+++ b/src/Flow/ETL/Transformer/Cast/CastArrayEntryEach.php
@@ -9,7 +9,7 @@ use Flow\ETL\Row;
 /**
  * @psalm-immutable
  */
-abstract class CastArrayEntryEach implements CastRow
+class CastArrayEntryEach implements CastRow
 {
     private string $arrayEntryName;
 

--- a/src/Flow/ETL/Transformer/Cast/CastEntries.php
+++ b/src/Flow/ETL/Transformer/Cast/CastEntries.php
@@ -9,7 +9,7 @@ use Flow\ETL\Row;
 /**
  * @psalm-immutable
  */
-abstract class CastEntries implements CastRow
+class CastEntries implements CastRow
 {
     /**
      * @var array<string>


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <li>abstract definition from CastEntries class</li>
    <li>abstract definition from CastArrayEntryEach class</li>
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->
